### PR TITLE
Don't require "rspec" in lib/rspec/instafail

### DIFF
--- a/lib/rspec/instafail.rb
+++ b/lib/rspec/instafail.rb
@@ -28,7 +28,6 @@ module RSpec
     Instafail
   else
     # rspec 2.x
-    require 'rspec'
     require 'rspec/core/formatters/progress_formatter'
     class Instafail < RSpec::Core::Formatters::ProgressFormatter
       def example_failed(example)


### PR DESCRIPTION
I removed the `require "rspec"` line in `lib/rspec/instafail` since it had no real business being there and it required me to use the rspec metagem when I only needed `rspec/core/formatters/bar_formatter` for testing purposes. :)

What do you think? :)
