### PR TITLE
use LoadErrors to detect RSpec version

### DIFF
--- a/lib/rspec/instafail.rb
+++ b/lib/rspec/instafail.rb
@@ -1,11 +1,7 @@
 module RSpec
   begin
-    # rspec 2.x
-    require 'rspec/core/formatters/progress_formatter'
     require 'rspec/instafail/rspec_2'
   rescue LoadError => try_rspec_1
-    # rspec 1.x
-    require 'spec/runner/formatter/progress_bar_formatter'
     require 'rspec/instafail/rspec_1'
   end
 

--- a/lib/rspec/instafail/rspec_1.rb
+++ b/lib/rspec/instafail/rspec_1.rb
@@ -1,3 +1,5 @@
+require 'spec/runner/formatter/progress_bar_formatter'
+
 module RSpec
   class Instafail < Spec::Runner::Formatter::ProgressBarFormatter
     def example_failed(example, counter, failure)

--- a/lib/rspec/instafail/rspec_2.rb
+++ b/lib/rspec/instafail/rspec_2.rb
@@ -1,3 +1,5 @@
+require 'rspec/core/formatters/progress_formatter'
+
 module RSpec
   class Instafail < RSpec::Core::Formatters::ProgressFormatter
     def example_failed(example)


### PR DESCRIPTION
I had a problem when running cucumber that the Spec constant appeared to be defined even though I was using RSpec 2, and therefore getting a LoadError when trying to load spec/runner/formatter/progress_bar_formatter.

This pull request uses LoadErrors to determine which rspec is loaded. It defaults to 2, and falls back to 1 if there is a LoadError.

Cheers,
/tooky
