### PR TITLE
When installed as plugin, lib is not in load-path

### DIFF
--- a/lib/rspec/instafail.rb
+++ b/lib/rspec/instafail.rb
@@ -1,8 +1,8 @@
 module RSpec
   begin
-    require 'rspec/instafail/rspec_2'
+    require File.dirname(__FILE__) + '/instafail/rspec_2'
   rescue LoadError # try rspec 1
-    require 'rspec/instafail/rspec_1'
+    require File.dirname(__FILE__) + '/instafail/rspec_1'
   end
 
   Instafail::VERSION = File.read( File.join(File.dirname(__FILE__),'..','..','VERSION') ).strip


### PR DESCRIPTION
The require statements in instafail.rb didn't work with my company's spec setup. I just made the require lines less error prone. There is no downside. 
