### PR TITLE
Documentation Change

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,7 +24,8 @@ As Gem:
     gem install rspec-instafail
 
     # spec/spec.opts (.rspec for rspec 2)
-    --require rspec/instafail
+    --require rspec/instafail/rspec_1 (for RSpec 1)
+    --require rspec/instafail/rspec_2 (for RSpec 2)
     --format RSpec::Instafail
 
 As plugin:


### PR DESCRIPTION
The new version of the gem breaks this syntax in the spec.opts file:

`--require rspec/instafail`

It looks like the new syntax is

`--require rspec/instafail/rspec_1` for RSpec 1

`--require rspec/instafail/rspec_2` for RSpec 2

I've amended the documentation to reflect this.
