### PR TITLE
Make instafail compatible with RSpec 2.8

### DIFF
--- a/lib/rspec/instafail/rspec_2.rb
+++ b/lib/rspec/instafail/rspec_2.rb
@@ -8,7 +8,7 @@ module RSpec
 
       # do what BaseTextFormatter#dump_failures would do
       index = failed_examples.size - 1
-      dump_pending_example_fixed(example, index) || dump_failure(example, index)
+      pending_fixed?(example) ? dump_pending_fixed(example, index) : dump_failure(example, index)
       dump_backtrace(example)
     end
   end

--- a/lib/rspec/instafail/version.rb
+++ b/lib/rspec/instafail/version.rb
@@ -1,2 +1,2 @@
 require 'rspec/instafail'
-RSpec::Instafail::VERSION = '0.2.1'
+RSpec::Instafail::VERSION = '0.3.0'

--- a/rspec-instafail.gemspec
+++ b/rspec-instafail.gemspec
@@ -9,4 +9,6 @@ Gem::Specification.new name, RSpec::Instafail::VERSION do |s|
   s.homepage = "http://github.com/grosser/#{name}"
   s.files = `git ls-files`.split("\n")
   s.license = "MIT"
+
+  s.add_dependency 'rspec-core', '>= 2.8.0'
 end


### PR DESCRIPTION
Commit

https://github.com/rspec/rspec-core/commit/423af1314d3e75fae55d6021dd7ee57ffff54998

changed a private API, on which instafail relied.
