### PR TITLE
Add support for RSpec 3

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@ task :default do
   Bundler.with_clean_env do
     sh "cd spec/rspec_1 && (bundle check || bundle) > /dev/null"
     sh "cd spec/rspec_2 && (bundle check || bundle) > /dev/null"
+    sh "cd spec/rspec_3 && (bundle check || bundle) > /dev/null"
   end
   sh "rspec spec/"
 end

--- a/lib/rspec/instafail.rb
+++ b/lib/rspec/instafail.rb
@@ -4,10 +4,14 @@ module RSpec
   lib = File.expand_path(File.dirname(File.dirname(__FILE__)))
   $LOAD_PATH << lib unless $LOAD_PATH.include?(lib)
 
-  begin
-    require "rspec/instafail/rspec_2"
-  rescue LoadError # try rspec 1
-    require "rspec/instafail/rspec_1"
+  if defined?(::RSpec::Core) && ::RSpec::Core::Version::STRING >= '3.0.0'
+    require "rspec/instafail/rspec_3"
+  else
+    begin
+      require "rspec/instafail/rspec_2"
+    rescue LoadError # try rspec 1
+      require "rspec/instafail/rspec_1"
+    end
   end
 
   require 'rspec/instafail/version'

--- a/lib/rspec/instafail/rspec_3.rb
+++ b/lib/rspec/instafail/rspec_3.rb
@@ -1,0 +1,18 @@
+require 'rspec/core/formatters/progress_formatter'
+
+module RSpec
+  class Instafail < RSpec::Core::Formatters::ProgressFormatter
+    RSpec::Core::Formatters.register self, :example_failed
+
+    def initialize(output)
+      super
+      @output = output
+      @failed_examples = []
+    end
+
+    def example_failed(failure)
+      @failed_examples << failure.example
+      @output.puts failure.fully_formatted(@failed_examples.size)
+    end
+  end
+end

--- a/spec/instafail_spec.rb
+++ b/spec/instafail_spec.rb
@@ -51,5 +51,33 @@ describe 'RSpec::Instafail' do
       @output.should_not include('ANCESTORS:3')
     end
   end
-end
 
+  context 'Rspec 3.x' do
+    before :all do
+      Bundler.with_clean_env do
+        @rspec_result = `cd spec/rspec_3 && bundle exec rspec a_test.rb --require ../../lib/rspec/instafail --format RSpec::Instafail --no-color --order default`
+      end
+    end
+
+    before do
+      @output = @rspec_result.dup
+    end
+
+    it "outputs failures at start of output" do
+      @output.should =~ /^\s+1\) x fails logically/m
+    end
+
+    it 'outputs errors in middle of output' do
+      @output.should =~ /\.\.\*\s*2\) x raises a simple error/m
+    end
+
+    it 'outputs the the ending block' do
+      @output.should =~ /Finished in \d\.\d+ seconds.*\s*9 examples, 4 failures, 1 pending/
+    end
+
+    it "does not add ancestors after failures" do
+      @output.should include('ANCESTORS:18')
+      @output.should_not include('ANCESTORS:19')
+    end
+  end
+end

--- a/spec/rspec_3/Gemfile
+++ b/spec/rspec_3/Gemfile
@@ -1,0 +1,2 @@
+source 'http://rubygems.org'
+gem 'rspec', '>=3.0'

--- a/spec/rspec_3/Gemfile.lock
+++ b/spec/rspec_3/Gemfile.lock
@@ -1,0 +1,22 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    diff-lcs (1.2.5)
+    rspec (3.0.0)
+      rspec-core (~> 3.0.0)
+      rspec-expectations (~> 3.0.0)
+      rspec-mocks (~> 3.0.0)
+    rspec-core (3.0.0)
+      rspec-support (~> 3.0.0)
+    rspec-expectations (3.0.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.0.0)
+    rspec-mocks (3.0.0)
+      rspec-support (~> 3.0.0)
+    rspec-support (3.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rspec (>= 3.0)

--- a/spec/rspec_3/a_test.rb
+++ b/spec/rspec_3/a_test.rb
@@ -1,0 +1,48 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'lib', 'rspec', 'instafail'))
+
+describe 'x' do
+  it 'fails logically' do
+    expect(1).to eq 2
+  end
+
+  it 'b' do
+  end
+
+  it 'c' do
+  end
+
+  it 'pends' do
+    pending
+    raise
+  end
+
+  it 'raises a simple error' do
+    raise 'shallow failure'
+  end
+
+  it 'raises a hidden error' do
+    error = ExceptionWrappingException.new('There is an error in this error.')
+    error.original_exception = RuntimeError.new('There is no error in this error.')
+    raise error
+  end
+
+  it 'e' do
+  end
+
+  context "ancestors" do
+    after do |example|
+      puts "ANCESTORS:#{example.example_group.ancestors.size}"
+    end
+
+    it "does not add ancestors on failure" do
+      raise "BAM"
+    end
+
+    it "does not add ancestors on failure" do
+    end
+  end
+end
+
+class ExceptionWrappingException < RuntimeError
+  attr_accessor :original_exception
+end


### PR DESCRIPTION
Hi, with RSpec 3 they changed the API for Formatters. I've added support for RSpec 3 here.

I copied the tests for rspec_2 into a rspec_3 and then wrote a formatter using the new api. The tests all pass. I didn't quite understand what was going on with the "ancestors" test, but they work so hopefully I did that correctly. 

I also tested it by building and installing the gem and running it against a project and it worked great.

Let me know if I missed anything.
