### PR TITLE
removed circular require

### DIFF
--- a/lib/rspec/instafail/version.rb
+++ b/lib/rspec/instafail/version.rb
@@ -1,2 +1,1 @@
-require 'rspec/instafail'
 RSpec::Instafail::VERSION = '0.2.5'


### PR DESCRIPTION
getting this error on rails 4.2.0 with rspec
```
/Users/wmd/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rspec-instafail-0.2.5/lib/rspec/instafail/version.rb:1: warning: loading in progress, circular require considered harmful - /Users/wmd/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rspec-instafail-0.2.5/lib/rspec/instafail.rb
```