### PR TITLE
Make a minor simplification to the RSpec 3 formatter

### DIFF
--- a/lib/rspec/instafail/rspec_3.rb
+++ b/lib/rspec/instafail/rspec_3.rb
@@ -6,13 +6,12 @@ module RSpec
 
     def initialize(output)
       super
-      @output = output
       @failed_examples = []
     end
 
     def example_failed(failure)
       @failed_examples << failure.example
-      @output.puts failure.fully_formatted(@failed_examples.size)
+      output.puts failure.fully_formatted(@failed_examples.size)
     end
   end
 end


### PR DESCRIPTION
If you use the `output` method, you don't need to manually set up the `@output` instance variable, since `super` takes care of that.