### PR TITLE
Update readme and add gem badge

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,7 @@
+# rspec-instafail
+[![Gem Version](https://badge.fury.io/rb/rspec-instafail.svg)](https://rubygems.org/gems/rspec-instafail)
+[![Build Status](https://travis-ci.org/grosser/rspec-instafail.svg)](https://travis-ci.org/grosser/rspec-instafail)
+
 Show failing specs instantly. Show passing spec as green dots as usual.
 
 Output
@@ -48,6 +52,4 @@ Authors
 
 [Michael Grosser](http://grosser.it)<br/>
 michael@grosser.it<br/>
-License: MIT<br/>
-[![Build Status](https://travis-ci.org/grosser/rspec-instafail.png)](https://travis-ci.org/grosser/rspec-instafail)
-
+License: MIT


### PR DESCRIPTION
The readme is easier to read with a title and badges at the top (instead of hidden at the end). Also svg badges are clearer than png.