### PR TITLE
Fix issue loading with rspec 3.4.0

### DIFF
--- a/lib/rspec/instafail.rb
+++ b/lib/rspec/instafail.rb
@@ -1,4 +1,4 @@
 module RSpec
-  version = Gem.loaded_specs["rspec"].version
+  version = Gem.loaded_specs["rspec-core"].version
   require "rspec/instafail/rspec_#{[3, version.segments.first].min}"
 end


### PR DESCRIPTION
When upgrading rspec from 3.1.0 to 3.4.0 I receive the following stacktrace running rspec:

```
NoMethodError: undefined method `version' for nil:NilClass
                 RSpec at /tmp/.gem/jruby/1.9/gems/rspec-instafail-0.4.0/lib/rspec/instafail.rb:3
                (root) at /tmp/.gem/jruby/1.9/gems/rspec-instafail-0.4.0/lib/rspec/instafail.rb:1
               require at org/jruby/RubyKernel.java:1071
                (root) at /tmp/jruby/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:1
               require at /tmp/jruby/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:128
                  each at org/jruby/RubyArray.java:1613
             requires= at /tmp/jruby/lib/ruby/gems/shared/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1295
             requires= at /tmp/jruby/lib/ruby/gems/shared/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1295
                  each at org/jruby/RubyArray.java:1613
  process_options_into at /tmp/jruby/lib/ruby/gems/shared/gems/rspec-core-3.4.4/lib/rspec/core/configuration_options.rb:109
  process_options_into at /tmp/jruby/lib/ruby/gems/shared/gems/rspec-core-3.4.4/lib/rspec/core/configuration_options.rb:108
             configure at /tmp/jruby/lib/ruby/gems/shared/gems/rspec-core-3.4.4/lib/rspec/core/configuration_options.rb:21
                 setup at /tmp/jruby/lib/ruby/gems/shared/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:105
                   run at /tmp/jruby/lib/ruby/gems/shared/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:92
                   run at /tmp/jruby/lib/ruby/gems/shared/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:78
                invoke at /tmp/jruby/lib/ruby/gems/shared/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:45
                  load at org/jruby/RubyKernel.java:1087
                (root) at /tmp/jruby/lib/ruby/gems/shared/gems/rspec-core-3.4.4/exe/rspec:4
```

The proposed change fixes that issue for me.