### PR TITLE
Update rspec dependencies to 3.5.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,18 +10,19 @@ GEM
     bump (0.5.1)
     diff-lcs (1.2.5)
     rake (10.4.2)
-    rspec (3.1.0)
-      rspec-core (~> 3.1.0)
-      rspec-expectations (~> 3.1.0)
-      rspec-mocks (~> 3.1.0)
-    rspec-core (3.1.7)
-      rspec-support (~> 3.1.0)
-    rspec-expectations (3.1.2)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.2)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.1.0)
-    rspec-mocks (3.1.3)
-      rspec-support (~> 3.1.0)
-    rspec-support (3.1.2)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
 
 PLATFORMS
   ruby
@@ -32,4 +33,4 @@ DEPENDENCIES
   rspec-instafail!
 
 BUNDLED WITH
-   1.12.3
+   1.12.5


### PR DESCRIPTION
When I try to use `rspec-instafail` with `rspec-rails 3.5.0`  bundle update will fail because `rspec-instafail` depends on lower version of `rspec-expectations`

so I ran `bundle update`. 

please let me know if this PR is invalid or wrong with the manner of this repository.

thanks.