### PR TITLE
Update dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,3 @@ DEPENDENCIES
   bump
   rake
   rspec-instafail!
-
-BUNDLED WITH
-   1.12.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,22 +7,22 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    bump (0.5.1)
-    diff-lcs (1.2.5)
-    rake (10.4.2)
-    rspec (3.5.0)
-      rspec-core (~> 3.5.0)
-      rspec-expectations (~> 3.5.0)
-      rspec-mocks (~> 3.5.0)
-    rspec-core (3.5.2)
-      rspec-support (~> 3.5.0)
-    rspec-expectations (3.5.0)
+    bump (0.8.0)
+    diff-lcs (1.3)
+    rake (13.0.1)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
+    rspec-expectations (3.9.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-mocks (3.5.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-support (3.5.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.2)
 
 PLATFORMS
   ruby
@@ -33,4 +33,4 @@ DEPENDENCIES
   rspec-instafail!
 
 BUNDLED WITH
-   1.12.5
+   1.17.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,4 +33,4 @@ DEPENDENCIES
   rspec-instafail!
 
 BUNDLED WITH
-   1.17.2
+   1.12.5


### PR DESCRIPTION
The gem hasn't been updated recently. It is up to a point where it can no longer be used by the new versions of `rspec-rails` and `rspec-core` gems, so un update of its dependencies is required.